### PR TITLE
Rename spf.h to libspf.h

### DIFF
--- a/.ci/release.jl
+++ b/.ci/release.jl
@@ -1,6 +1,6 @@
 ### Header Files Generation (used by BinaryBuilder) ###
 run(`sh -c "cargo install cbindgen"`)
-run(`sh -c "cbindgen --output target/spf.h --lang c --cpp-compat"`)
+run(`sh -c "cbindgen --output target/libspf.h --lang c --cpp-compat"`)
 
 ### BinaryBuilder Builds ###
 
@@ -65,7 +65,7 @@ mkpath("target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc/include
 mkpath("target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc/share/licenses/spf")
 
 mv("target/x86_64-pc-windows-msvc/release/spf.dll", "target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc/lib/spf.dll")
-cp("target/spf.h", "target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc/include/spf.h")
+cp("target/libspf.h", "target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc/include/libspf.h")
 cp("LICENSE-APACHE", "target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc/share/licenses/spf/LICENSE-APACHE")
 
 Tar.create("target/x86_64-pc-windows-msvc/release/spf.v0.5.0.x86_64-w64-msvc", "artifacts/spf.v0.5.0.x86_64-w64-msvc.tar.gz")


### PR DESCRIPTION
Renamed the release file spf.h to libspf.h, because that is how it is shown in the documentation.

Currently in the releases page of spf.rs, the contents of the spf.v0.5.0.x86_64-linux-gnu.tar.gz tarball contain the following files:
<img width="109" height="145" src="https://github.com/user-attachments/assets/1bfff84e-ae8c-451c-bc85-48ff9a4c7a5c" />

The documentation however is different:
<img width="952" height="204" src="https://github.com/user-attachments/assets/a67c7769-9fea-45ec-b29d-fd69fa2d8664" />
The documentation also mentions to download the tarball from the releases pages.

Let me know if I missed something, or am not doing something correctly. This is not really a required change but just shows better clarity in the documentation with the corresponding tarball releases.